### PR TITLE
Lots of changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,30 @@
-FROM python:2.7-onbuild
-
-# 1) COPY requirements.txt
-# 2) Run pip install on ^
-# 3) COPY . /usr/src/app
-
-#ENV GUNICORN_VERSION 19.3.0
+FROM python:2.7
 
 ## Install our dependencies
+RUN apt-get update \
+    && apt-get -y install \
+        libxml2-dev \
+        libxslt1-dev \
+        zlib1g-dev \
+        openssh-client \
+        build-essential \
+        texlive-latex-base \
+        texlive-latex-extra \
+        texlive-latex-recommended \
+        texlive-fonts-recommended \
+    && apt-get -y autoremove \
+    && apt-get clean
 
-RUN apt-get update && \
-    apt-get -y install libxml2-dev libxslt1-dev zlib1g-dev openssh-client build-essential && \
-#    pip install gunicorn==${GUNICORN_VERSION} && \
-    apt-get -y autoremove && \
-    apt-get clean
+WORKDIR /usr/src/app/readthedocs.org
 
 ## Apply our own overrides
-#COPY local_settings.py /usr/src/app/readthedocs.org/readthedocs/settings/local_settings.py
+COPY local_settings.py.example /usr/src/app/readthedocs.org/readthedocs/settings/local_settings.py
+COPY entrypoint.sh ./
 
-RUN cp ./local_settings.py readthedocs.org/readthedocs/settings/local_settings.py
+RUN pip install setuptools==19.2
+COPY readthedocs.org/requirements.txt ./
+COPY readthedocs.org/requirements/ ./requirements/
+RUN pip install -r requirements.txt
 
 ## Import our private key for cloning private repos
 RUN mkdir /root/.ssh
@@ -27,14 +34,8 @@ RUN chmod 700 /root/.ssh/id_rsa
 RUN echo "Host github.com\n\tStrictHostKeyChecking no\n" >> /root/.ssh/config
 RUN echo "    IdentityFile /root/.ssh/id_rsa" >> /etc/ssh/ssh_config
 
+COPY readthedocs.org/ /usr/src/app/readthedocs.org/
 
 ## This is a volume for our database
 VOLUME ["/persistent"]
-
-ENTRYPOINT ["./entrypoint.sh"]
-## Some defaults to pass to gunicorn/entrypoint
-#CMD ["-b", "0.0.0.0:80", "-w", "2", "readthedocs.wsgi:application"]
-
-## Not using gunicorn, just manage.py Let's setup some defaults, which can be
-# changed at runtime by the user (just specify a new cmd)
-CMD ["runserver", "0.0.0.0:80"]
+CMD ["./entrypoint.sh", "runserver", "0.0.0.0:80"]

--- a/default.conf
+++ b/default.conf
@@ -8,6 +8,10 @@ server {
     location / {
         #root   /usr/share/nginx/html;
         #index  index.html index.htm;
+        proxy_connect_timeout 300;
+        proxy_send_timeout 300;
+        proxy_read_timeout 300;
+        send_timeout 300;
         proxy_pass "http://rtd:80";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ rtd:
     volumes:
         - ./db:/persistent
     environment:
-        - "TEST_DATA=yes"
-        - "RTD_PRODUCTION_DOMAIN=production-domain:80"
+        - "TEST_DATA=no"
+        - "RTD_PRODUCTION_DOMAIN=docs.planfront.net:80"
     links:
         - elasticsearch
         - redis
@@ -20,7 +20,7 @@ nginx:
         - rtd
 elasticsearch:
     restart: always
-    image: elasticsearch:latest
+    image: elasticsearch:2.3.2
     command: elasticsearch -Des.network.host=0.0.0.0
     ports:
         - "9200:9200"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,11 +6,6 @@
 # We basically setup the db for the first time, create our user, and 
 #
 ##
-
-## Lets cd into the readthedocs checkout
-
-cd readthedocs.org
-
 ## Collect Variables
 DB_LOCATION=${DB_LOCATION:-/persistent/dev.db}
 

--- a/local_settings.py.example
+++ b/local_settings.py.example
@@ -7,6 +7,8 @@ PRODUCTION_DOMAIN = os.getenv('RTD_PRODUCTION_DOMAIN', 'localhost:8000')
 
 # Set the Slumber API host
 SLUMBER_API_HOST = os.getenv('RTD_SLUMBER_API_HOST', "http://" + PRODUCTION_DOMAIN)
+SLUMBER_USERNAME = 'admin'
+SLUMBER_PASSWORD = 'admin'
 
 # Turn off email verification
 ACCOUNT_EMAIL_VERIFICATION = 'none'


### PR DESCRIPTION
Need to pin the docker images as well as add a dep that was upgraded out
from under python's docker image.

I also had to specify real users for the SLUMBER work, and the real
hostname for the the env vars.

I also fixed up the docker image for rtd to have the tex work needed to
build pdfs, since that's on be default, and I was tired of it failing
builds on creation.

I also upgraded our RTD code to the latest master, since there were a
bunch of transative deps that were becoming problematic to use
unpinned/unfrozen.

[ticket: DEVOPS-969]